### PR TITLE
[fix] rollup-plugin-jay override noEmit flag to false

### DIFF
--- a/dev-environment/examples/tsconfig.json
+++ b/dev-environment/examples/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../library/tsconfig.json",
   "compilerOptions": {
     "allowImportingTsExtensions": false,
-    "noEmit": false,
     "lib": ["ES2022", "DOM"],
     "types": []
   }

--- a/packages/rollup-plugin/lib/index.ts
+++ b/packages/rollup-plugin/lib/index.ts
@@ -1,9 +1,12 @@
 // rollup-plugin-jay.js
+import { merge } from 'lodash';
 import { generateElementFile } from 'jay-compiler';
 import * as ts from 'typescript';
 import path from 'path';
 import * as fs from 'fs';
 import { TransformResult } from 'rollup';
+
+const JAY_TS_CONFIG_OVERRIDE = { compilerOptions: { noEmit: false } };
 
 function readTsConfigFile(tsConfigPath) {
     const { config, error } = ts.readConfigFile(tsConfigPath, (path) =>
@@ -31,6 +34,7 @@ function resolveTsConfig(options) {
 export default function jayCompiler(options = {}) {
     const tsConfigPath = resolveTsConfig(options);
     const tsConfig = tsConfigPath ? readTsConfigFile(tsConfigPath) : {};
+    const jayTsConfig = merge(tsConfig, JAY_TS_CONFIG_OVERRIDE);
     return {
         name: 'jay', // this name will show up in warnings and errors
         transform(code: string, id: string): TransformResult {
@@ -43,7 +47,7 @@ export default function jayCompiler(options = {}) {
                     if (code.length === 0) throw new Error('Empty code');
                     throw new Error(tsCode.validations.join('\n'));
                 }
-                let jsCode = ts.transpileModule(tsCode.val, tsConfig);
+                let jsCode = ts.transpileModule(tsCode.val, jayTsConfig);
                 return { code: jsCode.outputText, map: null };
             } else {
                 return { code, map: null };

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -16,9 +16,11 @@
   },
   "dependencies": {
     "jay-compiler": "workspace:^",
+    "lodash": "^4.17.21",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
+    "@types/lodash": "^4",
     "@types/node": "^20.9.2",
     "jay-dev-environment": "workspace:^",
     "tsup": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,6 +1951,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/lodash@npm:^4":
+  version: 4.14.202
+  resolution: "@types/lodash@npm:4.14.202"
+  checksum: a91acf3564a568c6f199912f3eb2c76c99c5a0d7e219394294213b3f2d54f672619f0fde4da22b29dc5d4c31457cd799acc2e5cb6bd90f9af04a1578483b6ff7
+  languageName: node
+  linkType: hard
+
 "@types/minimatch@npm:*":
   version: 5.1.2
   resolution: "@types/minimatch@npm:5.1.2"
@@ -4704,7 +4711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.4":
+"lodash@npm:^4.17.15, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -5898,9 +5905,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "rollup-plugin-jay@workspace:packages/rollup-plugin"
   dependencies:
+    "@types/lodash": ^4
     "@types/node": ^20.9.2
     jay-compiler: "workspace:^"
     jay-dev-environment: "workspace:^"
+    lodash: ^4.17.21
     tsup: ^8.0.0
     typescript: ^5.2.2
     vite: ^5.0.0


### PR DESCRIPTION
Problem
With noEmit: false, jay typesrcipt plugin does not generate the *.jay.html.ts files, then typescript plugin fails on
import { render } from "app.jay.html.ts"

Solution
Override the noEmit flag to false.