### PR TITLE
[compiler] runtime rewrite to not embed typescript

### DIFF
--- a/dev-environment/editor-setup/idea/runConfigurations/_template__of_JavaScriptTestRunnerVitest.xml
+++ b/dev-environment/editor-setup/idea/runConfigurations/_template__of_JavaScriptTestRunnerVitest.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="JavaScriptTestRunnerVitest">
+    <node-interpreter value="project" />
+    <vitest-options value="--reporter default" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jay",
   "scripts": {
     "build": "wsrun -te --report build",
-    "build:watch": "wsrun -p 'jay-(cli|compiler|component|json-patch|list-compare|reactive|runtime|secure|serialization)' -p 'rollup-plugin-jay' -m --prefix build:watch",
+    "build:watch": "wsrun -p 'jay-@(cli|compiler|component|json-patch|list-compare|reactive|runtime|secure|serialization)' -p 'rollup-plugin-jay' -m --prefix build:watch",
     "clean": "wsrun clean",
     "clean:node_modules": "rimraf node_modules && rimraf packages/*/node_modules && rimraf examples/*/node_modules && rimraf exploration/*/node_modules",
     "clean:node_modules:with-cache": "npm run clean:node_modules && yarn cache clean",

--- a/packages/rollup-plugin/lib/constants.ts
+++ b/packages/rollup-plugin/lib/constants.ts
@@ -1,0 +1,10 @@
+export const TS_EXTENSION = '.ts';
+export const JAY_EXTENSION = '.jay-html';
+export const JAY_TS_EXTENSION = '.jay-html.ts';
+export const JAY_DTS_EXTENSION = '.jay-html.d.ts';
+
+export enum RuntimeMode {
+    Trusted = 'trusted',
+    SandboxMain = 'sandboxMain',
+    SandboxWorker = 'sandboxWorker',
+}

--- a/packages/rollup-plugin/lib/definitions-compiler.ts
+++ b/packages/rollup-plugin/lib/definitions-compiler.ts
@@ -15,7 +15,7 @@ import path from 'node:path';
 export function jayDefinitions() {
     const generatedRefPaths: Set<string> = new Set();
     return {
-        name: 'jayDefinitions', // this name will show up in warnings and errors
+        name: 'jay:definitions', // this name will show up in warnings and errors
         async transform(code: string, id: string): Promise<TransformResult> {
             if (!isJayFile(id)) return { code: '', map: null };
 
@@ -25,8 +25,8 @@ export function jayDefinitions() {
             const parsedFile = parseJayFile(code, filename, dirname);
             const tsCode = generateElementDefinitionFile(parsedFile);
             checkValidationErrors(tsCode.validations);
-            writeDefinitionFile(dirname, filename, tsCode.val);
-            context.info(`Generated ${filename}.jay-html.d.ts`);
+            const generatedFilename = writeDefinitionFile(dirname, filename, tsCode.val);
+            context.info(`[transform] generated ${generatedFilename}`);
 
             const newRefsPaths = getRefsFilePaths(
                 generatedRefPaths,

--- a/packages/rollup-plugin/lib/helpers.ts
+++ b/packages/rollup-plugin/lib/helpers.ts
@@ -1,14 +1,24 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { PluginContext } from 'rollup';
+import { RuntimeMode, JAY_EXTENSION, JAY_TS_EXTENSION, JAY_DTS_EXTENSION } from './constants';
+import { mkdir, readFile } from 'node:fs/promises';
+import { writeFile } from 'fs/promises';
 
 export function isJayFile(filename: string): boolean {
-    return filename.endsWith('.jay-html') && !filename.startsWith('.jay-html');
+    return filename.endsWith(JAY_EXTENSION) && !filename.startsWith(JAY_EXTENSION);
 }
 
-export function getFileContext(filename: string): { filename: string; dirname: string } {
+export function isJayTsFile(filename: string): boolean {
+    return filename.endsWith(JAY_TS_EXTENSION) && !filename.startsWith(JAY_TS_EXTENSION);
+}
+
+export function getFileContext(
+    filename: string,
+    extension = JAY_EXTENSION,
+): { filename: string; dirname: string } {
     return {
-        filename: path.basename(filename).replace('.jay-html', ''),
+        filename: path.basename(filename).replace(extension, ''),
         dirname: path.dirname(filename),
     };
 }
@@ -23,26 +33,38 @@ export function checkCodeErrors(code: string): void {
     if (code.length === 0) throw new Error('Empty code');
 }
 
-export function writeDefinitionFile(dirname: string, filename: string, source: string): void {
-    const name = path.join(dirname, `${filename}.jay-html.d.ts`);
-    fs.writeFileSync(name, source, { encoding: 'utf8', flag: 'w' });
+export async function readFileWhenExists(
+    dirname: string,
+    filename: string,
+): Promise<string | undefined> {
+    try {
+        return (await readFile(path.resolve(dirname, filename))).toString();
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return undefined;
+        } else {
+            throw error;
+        }
+    }
 }
 
-export function writeGeneratedFile(
+export function writeDefinitionFile(dirname: string, filename: string, source: string): string {
+    const name = path.join(dirname, `${filename}${JAY_DTS_EXTENSION}`);
+    fs.writeFileSync(name, source, { encoding: 'utf8', flag: 'w' });
+    return name;
+}
+
+export async function writeGeneratedFile(
     context: PluginContext,
     projectRoot: string,
     outputDir: string,
     id: string,
     code: string,
-): void {
+): Promise<void> {
     if (!outputDir) return;
     const relativePath = path.dirname(path.relative(projectRoot, id));
-    const filename = `${path.basename(id)}.ts`;
-    const filePath = path.resolve(outputDir, relativePath, filename);
+    const filePath = path.resolve(outputDir, relativePath, path.basename(id));
     context.info(['Writing generated file', filePath].join(' '));
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, code, {
-        encoding: 'utf8',
-        flag: 'w',
-    });
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, code, { encoding: 'utf8', flag: 'w' });
 }

--- a/packages/rollup-plugin/lib/index.ts
+++ b/packages/rollup-plugin/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export * from './runtime-compiler';
 export * from './definitions-compiler';
 export * from './types';

--- a/packages/rollup-plugin/lib/types.ts
+++ b/packages/rollup-plugin/lib/types.ts
@@ -4,4 +4,5 @@ export interface JayRollupConfig {
     tsConfigFilePath?: string;
     tsCompilerOptionsOverrides?: CompilerOptions;
     outputDir?: string;
+    isWorker?: boolean;
 }

--- a/packages/rollup-plugin/test/jayRuntime/generate-project-sandbox-counter.test.ts
+++ b/packages/rollup-plugin/test/jayRuntime/generate-project-sandbox-counter.test.ts
@@ -12,7 +12,7 @@ async function generateProject(projectRoot: string): Promise<RollupBuild> {
     return await rollup({
         input: `${projectRoot}/source/index.ts`,
         plugins: [
-            jayRuntime({ tsConfigFilePath, outputDir: `../dist/main` }),
+            jayRuntime({ tsConfigFilePath, outputDir: '../dist/main' }),
             typescript({ tsconfig: tsConfigFilePath }),
         ],
     });

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,12 @@ Mark `.yarn` directory as excluded in IntelliJ.
 
 ### Development Environment Setup
 
+For IntelliJ IDEA, copy vitest runtime configuration to show console logs in test results:
+
+```shell
+cp -r dev-environment/editor-setup/idea .idea/
+```
+
 During development, it's convenient to watch for changes.
 You can run the following command from root to watch for all the packages,
 or run it from the specific package.


### PR DESCRIPTION
Problem
There was a need to specify typescript config twice:
* for jayRuntime rollup plugin, used by *.jay-html files
* for typescript rollup plugin, used by *.ts files

Solution
Change transform to resolveId and load,
resolveId returns an id of *.jay-html.ts,
load parses the file and returns a valid typescrip input. Then typescript plugin transforms the typescript input.