### PR TITLE
[compiler] fix vite inspect not showing transformations

### DIFF
--- a/packages/rollup-plugin/lib/helpers.ts
+++ b/packages/rollup-plugin/lib/helpers.ts
@@ -32,12 +32,9 @@ export function checkCodeErrors(code: string): void {
     if (code.length === 0) throw new Error('Empty code');
 }
 
-export async function readFileWhenExists(
-    dirname: string,
-    filename: string,
-): Promise<string | undefined> {
+export async function readFileWhenExists(filePath: string): Promise<string | undefined> {
     try {
-        return (await readFile(path.resolve(dirname, filename))).toString();
+        return (await readFile(filePath)).toString();
     } catch (error) {
         if (error.code === 'ENOENT') {
             return undefined;

--- a/packages/rollup-plugin/lib/runtime-compiler.ts
+++ b/packages/rollup-plugin/lib/runtime-compiler.ts
@@ -15,6 +15,10 @@ import { JAY_TS_EXTENSION, TS_EXTENSION } from './constants';
 import { readFile } from 'node:fs/promises';
 
 const TYPESCRIPT_EXTENSION = '.ts';
+enum JayFormat {
+    Html = 'html',
+    Typescript = 'typescript',
+}
 
 export function jayRuntime(jayOptions: JayRollupConfig = {}) {
     const projectRoot = path.dirname(jayOptions.tsConfigFilePath ?? process.cwd());
@@ -38,25 +42,26 @@ export function jayRuntime(jayOptions: JayRollupConfig = {}) {
 
             const context = this as PluginContext;
             context.info(`[load] start ${id}`);
-            const sourcePath = id.slice(0, id.length - TYPESCRIPT_EXTENSION.length);
-            const { filename, dirname } = getFileContext(sourcePath, JAY_TS_EXTENSION);
-            const existingTsFileSource = await readFileWhenExists(
-                dirname,
-                `${filename}${TS_EXTENSION}`,
-            );
+            const existingTsFileSource = await readFileWhenExists(id);
             if (existingTsFileSource) {
-                return { code: existingTsFileSource };
+                return {
+                    code: existingTsFileSource,
+                    meta: { jay: { format: JayFormat.Typescript } },
+                };
             }
 
+            const sourcePath = id.slice(0, id.length - TYPESCRIPT_EXTENSION.length);
             const jayCode = (await readFile(sourcePath)).toString();
             checkCodeErrors(jayCode);
             context.info(`[load] end ${id}`);
-            return { code: jayCode };
+            return { code: jayCode, meta: { jay: { format: JayFormat.Html } } };
         },
         async transform(code: string, id: string): Promise<TransformResult> {
             if (!isJayTsFile(id)) return null;
 
             const context = this as PluginContext;
+            if (context.getModuleInfo(id).meta.jay?.format !== JayFormat.Html) return null;
+
             context.info(`[transform] start ${id}`);
             const { filename, dirname } = getFileContext(id, JAY_TS_EXTENSION);
             const tsCode = generateElementFile(code, filename, dirname);


### PR DESCRIPTION
Tranform html files, do not transform TS files (manual examples). Remove optimize deps, transformations fail otherwise.