### PR TITLE
[refactor] simplify finding ast nodes in ts source file

### DIFF
--- a/packages/compiler/lib/ts-file/building-blocks/find-component-constructor-calls.ts
+++ b/packages/compiler/lib/ts-file/building-blocks/find-component-constructor-calls.ts
@@ -1,4 +1,3 @@
-import { SourceFileTransformerContext } from '../mk-transformer';
 import ts, {
     BindingName,
     Expression,
@@ -38,19 +37,15 @@ export function findComponentConstructorCalls(
 
 export function findComponentConstructorCallsBlock(
     makeJayComponentName: string,
-    { context, sourceFile }: SourceFileTransformerContext,
+    sourceFile: ts.SourceFile,
 ): MakeJayComponentConstructorCalls[] {
-    let foundConstructorCalls: MakeJayComponentConstructorCalls[] = [];
+    const foundConstructorCalls: MakeJayComponentConstructorCalls[] = [];
 
-    const findConstructorNames: ts.Visitor = (node) => {
-        foundConstructorCalls = [
-            ...foundConstructorCalls,
-            ...findComponentConstructorCalls(makeJayComponentName, node),
-        ];
-        return node;
-    };
+    function visit(node): void {
+        foundConstructorCalls.push(...findComponentConstructorCalls(makeJayComponentName, node));
+        ts.forEachChild(node, visit);
+    }
 
-    ts.visitEachChild(sourceFile, findConstructorNames, context);
-
+    ts.forEachChild(sourceFile, visit);
     return foundConstructorCalls;
 }

--- a/packages/compiler/lib/ts-file/component-secure-functions-transformer.ts
+++ b/packages/compiler/lib/ts-file/component-secure-functions-transformer.ts
@@ -26,7 +26,10 @@ function mkComponentSecureFunctionsTransformer(
     let makeJayComponent_ImportName = findMakeJayComponentImportTransformerBlock(sftContext);
     if (!Boolean(makeJayComponent_ImportName)) return sftContext.sourceFile;
 
-    let calls = findComponentConstructorCallsBlock(makeJayComponent_ImportName, sftContext);
+    let calls = findComponentConstructorCallsBlock(
+        makeJayComponent_ImportName,
+        sftContext.sourceFile,
+    );
     let constructorExpressions = calls.map(({ comp }) => comp);
     let constructorDefinitions = findComponentConstructorsBlock(constructorExpressions, sftContext);
     let foundEventHandlers = new FoundEventHandlers(

--- a/packages/compiler/test/ts-building-blocks/find-component-constructors.test.ts
+++ b/packages/compiler/test/ts-building-blocks/find-component-constructors.test.ts
@@ -11,14 +11,14 @@ import ts, {
 import { findComponentConstructorsBlock } from '../../lib/ts-file/building-blocks/find-component-constructors';
 import { findComponentConstructorCallsBlock } from '../../lib/ts-file/building-blocks/find-component-constructor-calls';
 
-describe('find component constructor', () => {
+describe('findComponentConstructorsBlock', () => {
     function testTransformer() {
         let state = {
             foundFunctions: undefined,
             transformer: mkTransformer((sourceFileTransformerData) => {
                 let componentConstructorCalls = findComponentConstructorCallsBlock(
                     'makeJayComponent',
-                    sourceFileTransformerData,
+                    sourceFileTransformerData.sourceFile,
                 );
                 let componentFunctionExpressions = componentConstructorCalls.map(
                     ({ comp }) => comp,

--- a/packages/compiler/test/ts-building-blocks/find-event-handler-functions.test.ts
+++ b/packages/compiler/test/ts-building-blocks/find-event-handler-functions.test.ts
@@ -17,7 +17,7 @@ describe('find component event handlers', () => {
             transformer: mkTransformer((sourceFileTransformerData) => {
                 let componentConstructorCalls = findComponentConstructorCallsBlock(
                     'makeJayComponent',
-                    sourceFileTransformerData,
+                    sourceFileTransformerData.sourceFile,
                 );
                 let componentFunctionExpressions = componentConstructorCalls.map(
                     ({ comp }) => comp,


### PR DESCRIPTION
Problem
There are two use cases for typescript transformers:
1. Transform a source file to a target file.
2. Extract specific AST nodes to be used in the transformation or parsing code to JayFile.

When we define a typescript transformer, we need to return the valid ts code. It's OK for case #1, but for the second case we don't need it.

Why is it bad?
Testing experience is a bit weird - one needs to:
* run the transform
* persist the found nodes in a variable
* return the source code as a transform result
* assert the value of the persisted variable.

Solution
For case #2, use a typescript visitor instead of the transformer.

It makes the testing straight forward,
as the expected data is returned by the visitor.
Also, the test requires less context.