### PR TITLE
[compiler] add JayFile type by format

### DIFF
--- a/packages/compiler/lib/core/jay-file-types.ts
+++ b/packages/compiler/lib/core/jay-file-types.ts
@@ -1,4 +1,6 @@
 import { HTMLElement } from 'node-html-parser';
+import { JsxBlock } from '../tsx-file/jsx-block';
+import { JayFormat } from './jay-format';
 
 export interface JayType {
     name: string;
@@ -96,13 +98,29 @@ export interface JayImportLink {
     sandbox?: boolean;
 }
 
-export interface JayFile {
+export interface JayHtmlFile {
+    format: JayFormat.JayHtml;
+    imports: JayImportLink[];
+    baseElementName: string;
     types: JayType;
     examples: Array<JayExample>;
+    body: HTMLElement;
+}
+
+export interface JayTsxFile {
+    format: JayFormat.JayTsx;
     imports: JayImportLink[];
-    body: HTMLElement | undefined;
+    baseElementName: string;
+    jsxBlock: JsxBlock;
+}
+
+export interface JayTypeScriptFile {
+    format: JayFormat.TypeScript;
+    imports: JayImportLink[];
     baseElementName: string;
 }
+
+export type JayFile = JayHtmlFile | JayTsxFile | JayTypeScriptFile;
 
 export interface JayYamlStructure {
     data: any;

--- a/packages/compiler/lib/core/jay-format.ts
+++ b/packages/compiler/lib/core/jay-format.ts
@@ -1,0 +1,5 @@
+export enum JayFormat {
+    JayHtml = 'jay-html',
+    JayTsx = 'jay-tsx',
+    TypeScript = 'typeScript',
+}

--- a/packages/compiler/lib/index.ts
+++ b/packages/compiler/lib/index.ts
@@ -3,6 +3,7 @@ export { parseJayFile, getJayHtmlImports } from './jay-file/jay-file-parser';
 export { WithValidations } from './core/with-validations';
 export { generateComponentRefsDefinitionFile } from './ts-file/ts-refs-file-generator';
 export * from './core/jay-file-types';
+export * from './core/jay-format';
 export { prettify } from './utils/prettify';
 export * from './ts-file/component-bridge-transformer';
 export * from './ts-file/component-secure-functions-transformer';

--- a/packages/compiler/lib/jay-file/jay-file-compiler.ts
+++ b/packages/compiler/lib/jay-file/jay-file-compiler.ts
@@ -21,7 +21,7 @@ import {
     JayAtomicType,
     JayComponentType,
     JayEnumType,
-    JayFile,
+    JayHtmlFile,
     JayHTMLType,
     JayImportedType,
     JayImportLink,
@@ -899,9 +899,9 @@ ${renderDynanicRefs(dynamicRefs)}
 }
 
 export function generateElementDefinitionFile(
-    parsedFile: WithValidations<JayFile>,
+    parsedFile: WithValidations<JayHtmlFile>,
 ): WithValidations<string> {
-    return parsedFile.map((jayFile: JayFile) => {
+    return parsedFile.map((jayFile) => {
         let types = generateTypes(jayFile.types);
         let {
             renderedRefs,
@@ -934,7 +934,7 @@ export function generateElementDefinitionFile(
 }
 
 export function generateElementFile(
-    jayFile: JayFile,
+    jayFile: JayHtmlFile,
     importerMode: RuntimeMode,
 ): WithValidations<string> {
     let types = generateTypes(jayFile.types);
@@ -963,7 +963,7 @@ export function generateElementFile(
     return new WithValidations(renderedFile, renderedImplementation.validations);
 }
 
-export function generateElementBridgeFile(jayFile: JayFile): string {
+export function generateElementBridgeFile(jayFile: JayHtmlFile): string {
     let types = generateTypes(jayFile.types);
     let { renderedRefs, renderedElement, elementType, renderedImplementation, refImportsInUse } =
         renderFunctionImplementation(
@@ -996,7 +996,7 @@ export function generateElementBridgeFile(jayFile: JayFile): string {
 const CALL_INITIALIZE_WORKER = `setWorkerPort(new JayPort(new HandshakeMessageJayChannel(self)));
 initializeWorker();`;
 
-export function generateSandboxRootFile(jayFile: JayFile): string {
+export function generateSandboxRootFile(jayFile: JayHtmlFile): string {
     // let { importedSymbols, importedSandboxedSymbols } = processImportedComponents(
     //     jayFile.imports,
     // );

--- a/packages/compiler/lib/jay-file/jay-file-parser.ts
+++ b/packages/compiler/lib/jay-file/jay-file-parser.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import {
     JayArrayType,
     JayEnumType,
-    JayFile,
+    JayHtmlFile,
     JayImportedType,
     JayImportLink,
     JayImportName,
@@ -20,6 +20,7 @@ import {
     resolvePrimitiveType,
 } from '../core/jay-file-types';
 import { ResolveTsConfigOptions } from '../ts-file/resolve-ts-config';
+import { JayFormat } from '../core/jay-format';
 
 export function isObjectType(obj) {
     return typeof obj === 'object' && !Array.isArray(obj);
@@ -163,7 +164,7 @@ export function parseJayFile(
     filename: string,
     filePath: string,
     options: ResolveTsConfigOptions,
-): WithValidations<JayFile> {
+): WithValidations<JayHtmlFile> {
     const normalizedFileName = normalizeFilename(filename);
     const baseElementName = capitalCase(normalizedFileName, { delimiter: '' });
     let root = parse(html);
@@ -190,7 +191,10 @@ export function parseJayFile(
         validations.push(`jay file must have exactly a body tag`);
         return new WithValidations(undefined, validations);
     }
-    return new WithValidations({ types, examples, imports, body, baseElementName }, validations);
+    return new WithValidations(
+        { format: JayFormat.JayHtml, types, examples, imports, body, baseElementName },
+        validations,
+    );
 }
 
 export function getJayHtmlImports(html: string): string[] {

--- a/packages/compiler/lib/ts-file/parse-jay-file/parse-type-script-file.ts
+++ b/packages/compiler/lib/ts-file/parse-jay-file/parse-type-script-file.ts
@@ -1,13 +1,17 @@
 import { WithValidations } from '../../core/with-validations';
-import { JayFile, JayUnknown } from '../../core/jay-file-types';
+import { JayTypeScriptFile } from '../../core/jay-file-types';
 import { capitalCase } from 'change-case';
 import { hasExtension, withoutExtension } from '../../core/runtime-mode';
 import { JAY_EXTENSION, JAY_TS_EXTENSION } from '../../core/constants';
 import { parseImportLinks } from './parse-import-links';
 import path from 'node:path';
 import { createTsSourceFileFromSource } from '../building-blocks/create-ts-source-file-from-source';
+import { JayFormat } from '../../core/jay-format';
 
-export function parseTypeScriptFile(filePath: string, code: string): WithValidations<JayFile> {
+export function parseTypeScriptFile(
+    filePath: string,
+    code: string,
+): WithValidations<JayTypeScriptFile> {
     const sourceFile = createTsSourceFileFromSource(filePath, code);
     const imports = parseImportLinks(sourceFile);
     const filename = path.basename(filePath);
@@ -18,7 +22,11 @@ export function parseTypeScriptFile(filePath: string, code: string): WithValidat
         { delimiter: '' },
     );
     return new WithValidations(
-        { types: JayUnknown, examples: [], imports, body: undefined, baseElementName },
+        {
+            format: JayFormat.TypeScript,
+            imports,
+            baseElementName,
+        } as JayTypeScriptFile,
         [],
     );
 }

--- a/packages/compiler/test/test-utils/ts-compiler-test-utils.ts
+++ b/packages/compiler/test/test-utils/ts-compiler-test-utils.ts
@@ -8,7 +8,7 @@ import {
     generateElementFile,
     generateImportsFileFromJayFile,
     generateImportsFileFromTsSource,
-    JayFile,
+    JayHtmlFile,
     parseJayFile,
     prettify,
     RuntimeMode,
@@ -29,7 +29,7 @@ export async function readFixtureFile(
 export async function readAndParseJayFile(
     folder: string,
     givenFile?: string,
-): Promise<WithValidations<JayFile>> {
+): Promise<WithValidations<JayHtmlFile>> {
     const dirname = path.resolve(__dirname, '../fixtures', folder);
     const file = givenFile || getFileFromFolder(folder);
     const filename = `${file}.jay-html`;

--- a/packages/compiler/test/ts-file/parse-jay-type-script-file.test.ts
+++ b/packages/compiler/test/ts-file/parse-jay-type-script-file.test.ts
@@ -1,4 +1,4 @@
-import { JayUnknown, parseTypeScriptFile, WithValidations } from '../../lib';
+import { JayFormat, JayUnknown, parseTypeScriptFile, WithValidations } from '../../lib';
 
 describe('parseJayTypeScriptFile', () => {
     const filePath = '/root/source/app.jay-html.ts';
@@ -50,8 +50,7 @@ export function render(viewState: AppViewState, options?: RenderElementOptions):
         expect(parseTypeScriptFile(filePath, code)).toEqual(
             new WithValidations(
                 {
-                    types: JayUnknown,
-                    examples: [],
+                    format: JayFormat.TypeScript,
                     imports: [
                         {
                             module: 'jay-runtime',
@@ -83,7 +82,6 @@ export function render(viewState: AppViewState, options?: RenderElementOptions):
                             sandbox: true,
                         },
                     ],
-                    body: undefined,
                     baseElementName: 'App',
                 },
                 [],

--- a/packages/compiler/test/tsx-file/parse-tsx-file.test.ts
+++ b/packages/compiler/test/tsx-file/parse-tsx-file.test.ts
@@ -1,5 +1,6 @@
 import { parseTsxFile } from '../../lib/tsx-file/parse-tsx-file';
 import { JayFile, JayUnknown, MAKE_JAY_TSX_COMPONENT, WithValidations } from '../../lib';
+import { prettifyHtml } from '../../lib/utils/prettify';
 
 describe('parseTsxFile', () => {
     const filename = 'dummy.tsx';
@@ -45,13 +46,15 @@ export const Counter = makeJayTsxComponent(CounterConstructor);
             ],
             baseElementName: 'Counter',
         } as JayFile);
-        // expect(jayFile.body.outerHTML).toEqual(`
-        //    <div>
-        //        <button ref="ref1">-</button>
-        //        <span style="color: red">{$1()}</span>
-        //        <button ref="ref2">+</button>
-        //    </div>
-        // `);
+        expect(prettifyHtml(jayFile.jsxBlock.getHtml())).toEqual(
+            prettifyHtml(`
+           <div>
+               <button ref="_ref_0">-</button>
+               <span style="color: red">{_memo_0()}</span>
+               <button ref="_ref_1">+</button>
+           </div>
+        `),
+        );
     });
 
     describe('on no component constructor', () => {

--- a/packages/rollup-plugin/lib/runtime/generate-code-from-structure.ts
+++ b/packages/rollup-plugin/lib/runtime/generate-code-from-structure.ts
@@ -11,11 +11,13 @@ import {
     generateSandboxRootFile,
     getModeFromExtension,
     JayFile,
+    JayFormat,
+    JayHtmlFile,
     RuntimeMode,
 } from 'jay-compiler';
 import { PluginContext } from 'rollup';
 import { JayPluginContext } from './jay-plugin-context';
-import { JayFormat, JayMetadata } from './metadata';
+import { JayMetadata } from './metadata';
 import { writeGeneratedFile } from '../common/files';
 
 export async function generateCodeFromStructure(
@@ -30,14 +32,14 @@ export async function generateCodeFromStructure(
     const mode = getModeFromExtension(id);
     const tsCode =
         format === JayFormat.JayHtml
-            ? generateCodeFromJayHtmlFile(mode, jayFile)
+            ? generateCodeFromJayHtmlFile(mode, jayFile as JayHtmlFile)
             : generateCodeFromTsFile(jayContext, mode, jayFile, id, code);
     await writeGeneratedFile(jayContext, context, id, tsCode);
 
     return tsCode;
 }
 
-export function generateCodeFromJayHtmlFile(mode: RuntimeMode, jayFile: JayFile): string {
+export function generateCodeFromJayHtmlFile(mode: RuntimeMode, jayFile: JayHtmlFile): string {
     switch (mode) {
         case RuntimeMode.MainTrusted:
         case RuntimeMode.MainSandbox:

--- a/packages/rollup-plugin/lib/runtime/get-jay-file-structure.ts
+++ b/packages/rollup-plugin/lib/runtime/get-jay-file-structure.ts
@@ -1,13 +1,14 @@
 import {
     checkValidationErrors,
     JayFile,
+    JayFormat,
     parseJayFile,
     parseTypeScriptFile,
     WithValidations,
 } from 'jay-compiler';
 import { PluginContext } from 'rollup';
 import { JayPluginContext } from './jay-plugin-context';
-import { getSourceJayMetadata, JayFormat, JayMetadata } from './metadata';
+import { getSourceJayMetadata, JayMetadata } from './metadata';
 import { getFileContext } from '../common/files';
 
 export async function getJayFileStructure(

--- a/packages/rollup-plugin/lib/runtime/metadata.ts
+++ b/packages/rollup-plugin/lib/runtime/metadata.ts
@@ -1,9 +1,5 @@
 import { CustomPluginOptions, PluginContext } from 'rollup';
-
-export enum JayFormat {
-    JayHtml = 'jay-html',
-    TypeScript = 'typeScript',
-}
+import { JayFormat } from 'jay-compiler';
 
 export interface JayMetadata {
     originId?: string;

--- a/packages/rollup-plugin/lib/runtime/resolve-id.ts
+++ b/packages/rollup-plugin/lib/runtime/resolve-id.ts
@@ -1,8 +1,8 @@
 import { CustomPluginOptions, PluginContext, ResolveIdResult, ResolvedId } from 'rollup';
 import { watchChangesFor } from './watch';
 import { SANDBOX_ROOT_PREFIX } from './sandbox';
-import { appendJayMetadata, JayFormat, jayMetadataFromModuleMetadata } from './metadata';
-import { hasExtension, JAY_QUERY_WORKER_TRUSTED_TS, TS_EXTENSION } from 'jay-compiler';
+import { appendJayMetadata, jayMetadataFromModuleMetadata } from './metadata';
+import { hasExtension, JAY_QUERY_WORKER_TRUSTED_TS, JayFormat, TS_EXTENSION } from 'jay-compiler';
 
 export interface ResolveIdOptions {
     attributes: Record<string, string>;

--- a/packages/rollup-plugin/test/lib/runtime/metadata.test.ts
+++ b/packages/rollup-plugin/test/lib/runtime/metadata.test.ts
@@ -1,11 +1,7 @@
-import {
-    getJayMetadata,
-    isWorkerRoot,
-    JayFormat,
-    JayMetadata,
-} from '../../../lib/runtime/metadata';
+import { getJayMetadata, isWorkerRoot, JayMetadata } from '../../../lib/runtime/metadata';
 import { mock } from 'vitest-mock-extended';
 import { PluginContext } from 'rollup';
+import { JayFormat } from 'jay-compiler';
 
 describe('metadata', () => {
     const originId = 'origin/id';

--- a/packages/rollup-plugin/test/lib/runtime/resolve-id.test.ts
+++ b/packages/rollup-plugin/test/lib/runtime/resolve-id.test.ts
@@ -5,6 +5,7 @@ import {
     JAY_EXTENSION,
     JAY_QUERY_MAIN_SANDBOX,
     JAY_QUERY_WORKER_TRUSTED_TS,
+    JayFormat,
     TS_EXTENSION,
 } from 'jay-compiler';
 import {
@@ -13,7 +14,7 @@ import {
     ResolveIdOptions,
     resolveJayModeFile,
 } from '../../../lib/runtime/resolve-id';
-import { JayFormat, JayMetadata } from '../../../lib/runtime/metadata';
+import { JayMetadata } from '../../../lib/runtime/metadata';
 import { SANDBOX_ROOT_PREFIX } from '../../../lib/runtime/sandbox';
 
 describe('resolve-id', () => {

--- a/packages/rollup-plugin/test/lib/runtime/transform.test.ts
+++ b/packages/rollup-plugin/test/lib/runtime/transform.test.ts
@@ -5,6 +5,7 @@ import {
     JAY_QUERY_MAIN_SANDBOX,
     JAY_QUERY_WORKER_TRUSTED_TS,
     JayAtomicType,
+    JayFormat,
     JayObjectType,
     JayUnknown,
     prettify,
@@ -12,7 +13,7 @@ import {
 } from 'jay-compiler';
 import { JayPluginContext } from '../../../lib/runtime/jay-plugin-context';
 import { readTestFile } from '../../test-utils/file-utils';
-import { JayFormat, JayMetadata } from '../../../lib/runtime/metadata';
+import { JayMetadata } from '../../../lib/runtime/metadata';
 import { transformJayFile } from '../../../lib/runtime/transform';
 import { getJayFileStructure } from '../../../lib/runtime/get-jay-file-structure';
 import { removeComments } from '../../../../compiler/lib/utils/prettify';
@@ -80,10 +81,8 @@ describe('transformJayFile', () => {
 
             expect(await prettified(result)).toEqual(code);
             expect(jayContext.getCachedJayFile(id)).toEqual({
+                format: JayFormat.TypeScript,
                 baseElementName: 'Counter',
-                types: JayUnknown,
-                examples: [],
-                body: undefined,
                 imports: [
                     {
                         module: './counter.jay-html',


### PR DESCRIPTION
Problem
Each format has different structure and data that it emits. If we put everything in a single file,
it would hard to know what data can be expected from it.

Solution
Extract different JayFile types.
This way it's easy to define format specific parsers and compilers.