### PR TITLE
fix typo in readme low-level APIs heading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -282,7 +282,7 @@ The examples are organized into 5 categories
 - Jay Context
   - [scrum-board-with-context](examples%2Fjay-context%2Fscrum-board-with-context) - the same scrum board example using jay context
   - [todo-with-context](examples%2Fjay-context%2Ftodo-with-context) - the same todo list example using jay context
-- Jay Low Leven APIs
+- Jay Low Level APIs
   - [counter-raw](examples%2Fjay-low-level-apis%2Fcounter-raw) - counter example not using the Jay Component APIs. Only using @jay-framework/runtime.
   - [todo-raw](examples%2Fjay-low-level-apis%2Ftodo-raw) - todo list not using the Jay Component APIs. Only using @jay-framework/runtime.
 - Jay Stack


### PR DESCRIPTION
## Summary
- fix a typo in `readme.md` by changing "Jay Low Leven APIs" to "Jay Low Level APIs"
- keep documentation terminology consistent and easier to scan

## Test plan
- [x] verify the heading text in `readme.md`
- [x] confirm only the docs typo change is included in this PR

Made with [Cursor](https://cursor.com)