### PR TITLE
fix(stack-cli): clarify editor URL in dev server startup output

### DIFF
--- a/packages/jay-stack/stack-cli/README.md
+++ b/packages/jay-stack/stack-cli/README.md
@@ -70,7 +70,8 @@ When test mode is enabled, the startup output includes the test endpoints:
 ```
 🚀 Jay Stack dev server started successfully!
 📱 Dev Server: http://localhost:3300
-🎨 Editor Server: http://localhost:3301 (ID: init)
+🎨 Editor (AIditor): http://localhost:3300/aiditor
+   (editor socket server on http://localhost:3301, ID: init)
 📁 Pages directory: ./src/pages
 🧪 Test Mode: enabled
    Health: http://localhost:3300/_jay/health

--- a/packages/jay-stack/stack-cli/lib/server.ts
+++ b/packages/jay-stack/stack-cli/lib/server.ts
@@ -198,7 +198,8 @@ export async function startDevServer(options: StartDevServerOptions = {}) {
     httpServer.listen(devServerPort, () => {
         log.important(`🚀 Jay Stack dev server started successfully!`);
         log.important(`📱 Dev Server: http://localhost:${devServerPort}`);
-        log.important(`🎨 Editor Server: http://localhost:${editorPort} (ID: ${editorId})`);
+        log.important(`🎨 Editor (AIditor): http://localhost:${devServerPort}/aiditor`);
+        log.important(`   (editor socket server on http://localhost:${editorPort}, ID: ${editorId})`);
         log.important(`📁 Pages directory: ${resolvedConfig.devServer.pagesBase}`);
         if (fs.existsSync(publicPath)) {
             log.important(`📁 Public folder: ${resolvedConfig.devServer.publicFolder}`);


### PR DESCRIPTION
## Problem

The dev server startup banner prints:

```
🎨 Editor Server: http://localhost:3301 (ID: init)
```

This reads like a URL you open in a browser, but `:3301` (the editor port) is a **Socket.io / port-discovery backend**. Its only HTTP route is `/editor-connect`; every other path — including `/`, which is what a browser requests — returns `Not Found`. So users naturally open the advertised link and hit a 404, thinking the editor is broken.

## Change

- `packages/jay-stack/stack-cli/lib/server.ts`: relabel the line to point at the actual editor UI (`/aiditor` on the **dev** server port) and demote the socket server URL to a clarifying sub-line.
- `packages/jay-stack/stack-cli/README.md`: update the sample startup output to match.

New output:

```
🎨 Editor (AIditor): http://localhost:3000/aiditor
   (editor socket server on http://localhost:3101, ID: init)
```

The `📱 Dev Server:` line is intentionally left unchanged, since the smoke tests parse it to detect the server URL.

## Open questions for maintainers

- **`/aiditor` assumption.** The `/aiditor` route is contributed by the `aiditor` plugin, not the CLI core. If a project runs the dev server without that plugin, the printed link won't resolve. Happy to gate the AIditor line on the plugin being present, or to reword so it only clarifies the socket server without asserting `/aiditor` — whichever you prefer.
- Left the historical `design-log/83 - dev server logging and timing.md` sample output untouched, treating design-log entries as dated records rather than living docs. Let me know if you'd rather I update those too.
## Validation

Built and tested locally against `@jay-framework/jay-stack-cli`:

- `yarn install` (workspace) — ✅
- `wsrun -p @jay-framework/jay-stack-cli -r -t build` — ✅ (edit confirmed present in compiled `dist/index.js`)
- `build:check-types` (tsc) — ✅ no type errors
- `test` (vitest) — ✅ 108/108 passing across 7 files

Scoped to the `stack-cli` package (where the change lives), not a full-monorepo `yarn test`.